### PR TITLE
chore: set buildx progress to plain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  BUILDKIT_PROGRESS: plain
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
 permissions:
   contents: read
 
+env:
+  BUILDKIT_PROGRESS: plain
+
 jobs:
   version:
     runs-on: ubuntu-latest


### PR DESCRIPTION
For better readability of CI logs.